### PR TITLE
enable vanguards

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -227,6 +227,13 @@ services:
       - nitter
       - teddit
     environment:
+      TOR_ENABLE_VANGUARDS: 'true'
+
+      VANGUARDS_EXTRA_OPTIONS: |
+        [Global]
+        enable_cbtverify = True
+        loglevel = INFO
+
       MONEROD_TOR_SERVICE_HOSTS: 18089:monerod:18089
       MONEROD_TOR_SERVICE_VERSION: '3'
       NITTER_TOR_SERVICE_HOSTS: 80:nitter:8080


### PR DESCRIPTION
The `goldy/tor-hidden-service:latest` can make use of the [vanguards project](https://github.com/mikeperry-tor/vanguards).
The added environment variable enable vanguards.